### PR TITLE
Zelin web6.0

### DIFF
--- a/web6/web6.go
+++ b/web6/web6.go
@@ -204,7 +204,7 @@ func GetStartingUdnData(db_web *sql.DB, db *sql.DB, web_site map[string]interfac
 
 	// Prepare the udn_data with it's fixed pools of data
 	//udn_data["widget"] = *NewTextTemplateMap()
-	udn_data["web_protocol"] = web_protocol_action
+	udn_data["web_protocol_action"] = web_protocol_action
 	udn_data["data"] = make(map[string]interface{})
 	udn_data["temp"] = make(map[string]interface{})
 	udn_data["output"] = make(map[string]interface{}) // Staging output goes here, can share them with appending as well.

--- a/web6/web6.go
+++ b/web6/web6.go
@@ -361,6 +361,8 @@ func dynamicPage_API(db_web *sql.DB, db *sql.DB, web_site map[string]interface{}
 
 	fmt.Printf("Starting UDN Data: %v\n\n", udn_data)
 
+	fmt.Printf("Params: %v\n\n", param_map)
+
 	// Get the base widget
 	sql := fmt.Sprintf("SELECT * FROM web_widget")
 	all_widgets := Query(db_web, sql)


### PR DESCRIPTION
In opsdb for the table web_site_api, please change the unique constraint to have the fields (web_site_id, name, web_protocol_action_id) instead of (web_site_id, name). This will allow multiple entries in web_site_api table for one API point with different web_protocol_action (ex: GET + POST for the api endpoint /api/vendor_order).

Added handlers to accept POST + PUT params and will store the params in udn_data["param"]. For POST + PUT, the params are expected to be in the body of the request. JSON could also be sent in a post request like before. 